### PR TITLE
Fix typo in feeds.config.default

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git;2.9-dev
-src-git morse https://github.com/MorseMicro/morse-feed.git;2-9.dev
+src-git morse https://github.com/MorseMicro/morse-feed.git;2.9-dev
 src-git prpl https://github.com/MorseMicro/feed-prpl.git;2.9-dev


### PR DESCRIPTION
There was a small typo in feeds.config.default stopping the `./scripts/morse_setup.sh` from completing. That is fixed with this.