### PR TITLE
script: Fix morse_setup compatible to run in symbolic link

### DIFF
--- a/scripts/morse_setup.sh
+++ b/scripts/morse_setup.sh
@@ -158,7 +158,7 @@ patch_feeds_packages(){
 
 
 # script has to run from openwrt top
-if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]; then
+if [[ "$(readlink -f $(pwd))" != "$(git rev-parse --show-toplevel)" ]]; then
     usage 1
 fi
 


### PR DESCRIPTION
In linux, $(pwd) only read the "current working directory path" instead of "absolute path", and this is a bit tricky when the path is from a symbolic link.
For example, we got a openwrt repo at path "/mnt/ssd_500gb/github/openwrt"
If using ```ln -s /mnt/ssd_500gb/github/openwrt ~/openwrt``` to link into home directory, in path ```~/openwrt```, the following command will show:

```
git rev-parse --show-toplevel	-> /mnt/ssd_500gb/github/openwrt
echo $(pwd)						-> /home/elwin/openwrt
echo $(readlink -f $(pwd))		-> /mnt/ssd_500gb/github/openwrt
```

Fix this issue to read the realpath of pwd so that when running in a link, morse_setup will find the correct path.
